### PR TITLE
update for python 3

### DIFF
--- a/requests_cloudkit/cloudkit.py
+++ b/requests_cloudkit/cloudkit.py
@@ -27,16 +27,16 @@ class CloudKitAuth(requests.auth.AuthBase):
     See: https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/index.html
     """
 
-    def __init__(self, key_id, pem=None, key_file_name=None):
+    def __init__(self, key_id, key_file_name=None, pem=None):
         """
         The key_id is required. You can find it when you create a
         server-to-server certificate in your CloudKit Dashboard.
         """
-        self.key_id = key_id
-        self.pem = pem
+        self.key_id        = key_id
         self.key_file_name = key_file_name
+        self.pem           = pem
 
-        if not self.pem and not self.key_file_name:
+        if not self.key_file_name and not self.pem:
             raise Exception("Requires one of pem or key_file_name")
 
     def __call__(self, r):

--- a/requests_cloudkit/cloudkit.py
+++ b/requests_cloudkit/cloudkit.py
@@ -19,45 +19,73 @@ import datetime
 import ecdsa
 import hashlib
 import json
-import pytz
 import requests
-import tempfile
+import pytz
 
 class CloudKitAuth(requests.auth.AuthBase):
-    def __init__(self, key_id, key_file_name):
+    """
+    See: https://developer.apple.com/library/archive/documentation/DataManagement/Conceptual/CloudKitWebServicesReference/index.html
+    """
+
+    def __init__(self, key_id, pem=None, key_file_name=None):
+        """
+        The key_id is required. You can find it when you create a
+        server-to-server certificate in your CloudKit Dashboard.
+        """
         self.key_id = key_id
+        self.pem = pem
         self.key_file_name = key_file_name
+
+        if not self.pem and not self.key_file_name:
+            raise Exception("Requires one of pem or key_file_name")
 
     def __call__(self, r):
         dt = datetime.datetime.now(tz=pytz.UTC)
         dt = dt.replace(microsecond=0)
         formatted_date = dt.isoformat().replace("+00:00", "Z")
+        sig = self.make_signature(formatted_date, r.body, r.path_url)
 
         r.headers = {
             'Content-Type': "text/plain",
-            'X-Apple-CloudKit-Request-SignatureV1': self.make_signature(formatted_date, r.body, r.path_url),
+            'X-Apple-CloudKit-Request-SignatureV1': sig,
             'X-Apple-CloudKit-Request-KeyID': self.key_id,
             'X-Apple-CloudKit-Request-ISO8601Date': formatted_date
         }
         return r
 
     def make_signature(self, formatted_date, body, path):
-        signature = "{}:{}:{}".format(formatted_date, self.encode_body(body), path)
+        """
+        See: "Accessing CloudKit Using a Server-to-Server Key"
+        """
+        to_sign = "{}:{}:{}".format(formatted_date,
+                                    self.encode_body(body),
+                                    path)
 
-        with tempfile.NamedTemporaryFile() as signature_file, tempfile.NamedTemporaryFile() as body_file:
-            body_file.write(signature)
-            body_file.seek(0)
+        sk = ecdsa.SigningKey.from_pem(self.get_key())
+        signature = sk.sign(to_sign.encode(),
+                            hashfunc=hashlib.sha256,
+                            sigencode=ecdsa.util.sigencode_der)
 
-            sk = ecdsa.SigningKey.from_pem(open(self.key_file_name).read())
-            signature = sk.sign(body_file.read(), hashfunc=hashlib.sha256, sigencode=ecdsa.util.sigencode_der)
-            return base64.b64encode(signature)
+        return base64.b64encode(signature)
+
+    def get_key(self):
+        """
+        Return the private key PEM contents as a byte string.
+        """
+        if self.pem:
+            return self.pem
+        else:
+            return open(self.key_file_name).read()
 
     def encode_body(self, body):
+        """
+        Return the request body. This is the base64 string encoded
+        SHA-256 hash of the body.
+        """
         if body is None:
             body = ""
         elif type(body) != str:
             body = json.dumps(body, separators=(',', ':'))
 
-        h = hashlib.sha256(body)
-        return base64.b64encode(h.digest())
-
+        h = hashlib.sha256(body.encode())
+        return base64.b64encode(h.digest()).decode()


### PR DESCRIPTION
Added a few docblocks with relevant links to Apple documentation (although it says archived?).

Updated the encoding/decoding of bytes to support python3.

Removed the apparenly unnecessary tempfile roundtrip.

Added the ability to provide the pem bytes directly to the constructor (in case you have the PEM itself in an env var or somesuch, although I suppose you could use a BytesIO at that point...)

Tried to keep lines under 80 chars.